### PR TITLE
目录中参考文献的链接

### DIFF
--- a/buaa.cls
+++ b/buaa.cls
@@ -822,6 +822,8 @@
 }
 \newcommand{\Bib}[2]{%参考文献
   \bibliographystyle{#1}
+  \clearpage
+  \phantomsection
   \addcontentsline{toc}{chapter}{参考文献}
   \bibliography{#2}
 }

--- a/buaa_mac.cls
+++ b/buaa_mac.cls
@@ -827,6 +827,8 @@
 }
 \newcommand{\Bib}[2]{%参考文献
   \bibliographystyle{#1}
+  \clearpage
+  \phantomsection
   \addcontentsline{toc}{chapter}{参考文献}
   \bibliography{#2}
 }


### PR DESCRIPTION
点击目录中的`参考文献`的时候，链接指向的是`结论`，需要加一个`\phantomsection`来让目录中的链接指向正确的位置。