### PR TITLE
LoadClass应位于ExecuteOptions之后

### DIFF
--- a/Template.tex
+++ b/Template.tex
@@ -19,6 +19,10 @@
 %=================================================================
 \documentclass[doctor,privacy,twoside]{buaa}
 
+% CTeX在Linux下默认使用Fandol字体，某些生僻字无法显示。
+% 在系统中安装方正字体后使用如下的fontset选项可避免生僻字乱码的问题。
+%\documentclass[doctor,privacy,twoside,fontset=founder]{buaa}
+
 %% Mac系统请使用buaa_mac，并使用XeLaTeX编译。
 %\documentclass[doctor,privacy,twoside]{buaa_mac}
 

--- a/Template.tex
+++ b/Template.tex
@@ -19,7 +19,8 @@
 %=================================================================
 \documentclass[doctor,privacy,twoside]{buaa}
 
-% CTeX在Linux下默认使用Fandol字体，某些生僻字无法显示。
+% 此处可加入ctexbook文档类的选项，将会被传递给ctexbook。
+% 一种使用场景为：CTeX在Linux下默认使用Fandol字体，某些生僻字无法显示。
 % 在系统中安装方正字体后使用如下的fontset选项可避免生僻字乱码的问题。
 %\documentclass[doctor,privacy,twoside,fontset=founder]{buaa}
 

--- a/buaa.cls
+++ b/buaa.cls
@@ -24,57 +24,6 @@
 \ProvidesClass{buaa}[2018/11/22 v2.0 BUAA thesis class]
 \typeout{This is LaTeX template buaa, Version 2.0 (based on CTex) 11-22-2018}
 
-\usepackage{graphicx}
-\def\BUAAThesisVer{v2.0 11-22-2018}
-\def\BUAAThesis{%
- B%
- {\fontsize{0.8em}{\baselineskip}\selectfont
- \kern-.12em\lower.5ex\hbox{U}%
- \kern-.46em\raise.47ex\hbox{A}%
- \kern-.12em A%
-}
- \kern-.35emT%
- \kern-.22em\lower.5ex\hbox{H}%
- \kern-.08em E%
- \kern-.05em\lower.5ex\hbox{S}%
- \kern-.26em I%
- \kern-.26em\raise.5ex\hbox{\rotatebox[origin=c]{180}{S}}%
-}
-
-% 引用ctexbook: 小4,1.5倍行距
-\LoadClass[UTF8,zihao=-4,linespread=1.7]{ctexbook}%1.5+0.2行间距
-
-%% 预声明
-\RequirePackage{ifthen}       % ifthenelse/equal/isundefined等判断比较命令
-\RequirePackage{geometry}     % 设置页边距
-\RequirePackage{fancyhdr}     % 设置页眉页脚
-\RequirePackage{setspace}     % 设置行间距
-\RequirePackage{times}        % Times New Roman字体
-\RequirePackage{float}        % 图片
-\RequirePackage{graphicx}     % 图片
-\RequirePackage{subfigure}    % 图片
-\RequirePackage{epstopdf}     % 图片
-\RequirePackage{array}        %
-\RequirePackage{enumitem}     %
-\RequirePackage{booktabs}     % 表格上下粗线
-\RequirePackage{longtable}    % 长表格
-\RequirePackage{multirow}     % 多行表格
-\RequirePackage{caption}      % 标题设置
-\RequirePackage{algorithm2e}  % 算法环境
-\RequirePackage{listings}     % 代码环境
-\RequirePackage{amsmath}      % 数学
-\RequirePackage{amsthm}       % 定理
-\RequirePackage{titletoc}     % 目录
-\RequirePackage{remreset}     % 计数器设置
-\RequirePackage{hyperref}     % 超链接
-\RequirePackage{etoolbox}     % \AtBeginDocument等宏命令
-\RequirePackage{pifont}       % 画五角星
-\RequirePackage{color}        % To provide color for soul
-\RequirePackage{soul}         % To highlight text
-\RequirePackage[sort&compress]{natbib}              % BibTex
-\DeclareGraphicsExtensions{.eps,.ps,.png,.jpg,.bmp} % 声明使用图像格式
-\newcommand{\highlight}[1]{\colorbox{yellow}{#1}}   % 高亮注释
-
 %% 选项
 %% 论文类型
 \DeclareOption{master}{\gdef\@thesis{master}}             % 学术硕士论文
@@ -141,6 +90,57 @@
 \ExecuteOptions{master,pubilc,oneside,a4paper,sub4section}
 \setcounter{secnumdepth}{5}
 \ProcessOptions\relax
+
+% 引用ctexbook: 小4,1.5倍行距
+\LoadClass[UTF8,zihao=-4,linespread=1.7]{ctexbook}%1.5+0.2行间距
+
+\usepackage{graphicx}
+\def\BUAAThesisVer{v2.0 11-22-2018}
+\def\BUAAThesis{%
+ B%
+ {\fontsize{0.8em}{\baselineskip}\selectfont
+ \kern-.12em\lower.5ex\hbox{U}%
+ \kern-.46em\raise.47ex\hbox{A}%
+ \kern-.12em A%
+}
+ \kern-.35emT%
+ \kern-.22em\lower.5ex\hbox{H}%
+ \kern-.08em E%
+ \kern-.05em\lower.5ex\hbox{S}%
+ \kern-.26em I%
+ \kern-.26em\raise.5ex\hbox{\rotatebox[origin=c]{180}{S}}%
+}
+
+%% 预声明
+\RequirePackage{ifthen}       % ifthenelse/equal/isundefined等判断比较命令
+\RequirePackage{geometry}     % 设置页边距
+\RequirePackage{fancyhdr}     % 设置页眉页脚
+\RequirePackage{setspace}     % 设置行间距
+\RequirePackage{times}        % Times New Roman字体
+\RequirePackage{float}        % 图片
+\RequirePackage{graphicx}     % 图片
+\RequirePackage{subfigure}    % 图片
+\RequirePackage{epstopdf}     % 图片
+\RequirePackage{array}        %
+\RequirePackage{enumitem}     %
+\RequirePackage{booktabs}     % 表格上下粗线
+\RequirePackage{longtable}    % 长表格
+\RequirePackage{multirow}     % 多行表格
+\RequirePackage{caption}      % 标题设置
+\RequirePackage{algorithm2e}  % 算法环境
+\RequirePackage{listings}     % 代码环境
+\RequirePackage{amsmath}      % 数学
+\RequirePackage{amsthm}       % 定理
+\RequirePackage{titletoc}     % 目录
+\RequirePackage{remreset}     % 计数器设置
+\RequirePackage{hyperref}     % 超链接
+\RequirePackage{etoolbox}     % \AtBeginDocument等宏命令
+\RequirePackage{pifont}       % 画五角星
+\RequirePackage{color}        % To provide color for soul
+\RequirePackage{soul}         % To highlight text
+\RequirePackage[sort&compress]{natbib}              % BibTex
+\DeclareGraphicsExtensions{.eps,.ps,.png,.jpg,.bmp} % 声明使用图像格式
+\newcommand{\highlight}[1]{\colorbox{yellow}{#1}}   % 高亮注释
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% 数学环境

--- a/tex/chap_instruction.tex
+++ b/tex/chap_instruction.tex
@@ -24,7 +24,7 @@ Again，这是北航论文\LaTeX{}模板（\CTeX{}-Based）\BUAAThesis{}。
  \verb|tex/*.tex|             & $\triangleright$ 本模板样例中的独立章节\\
 \end{tabular}\\
 
-通过 \verb|\documentclass[<thesis>,<permission>,<printtype>]{buaa}|载入宏包：
+通过 \verb|\documentclass[<thesis>,<permission>,<printtype>,<ctexbookoptions>]{buaa}|载入宏包：
 \begin{itemize}[leftmargin=3cm]
   \item[{\tt thesis} $\triangleright$]  论文类型(thesis)，可选值：\\
     a) 学术硕士论文（\verb|master|）[缺省值]\\
@@ -50,7 +50,12 @@ Again，这是北航论文\LaTeX{}模板（\CTeX{}-Based）\BUAAThesis{}。
     --- e.4) 绝密永久（\verb|topsecret*|）
   \item[{\tt printtype} $\triangleright$] 打印属性(printtype)，可选值： \\
     a) 单面打印（\verb|onside|）[缺省值]\\
-    b) 双面打印（\verb|twoside|）
+    b) 双面打印（\verb|twoside|）\\
+  \item[{\tt ctexbookoptions} $\triangleright$] 其他选项将被传递给{\tt ctexbook}文档类。\\
+  一种使用场景为：
+  CTeX在Linux下默认使用Fandol字体，受字体所限，某些生僻字（如姓名）无法显示。
+  一种解决办法为自行在系统中安装CTeX所需的字体，如方正字体。
+  使用{\tt ctexbookoptions}机制，将{\tt fontset=founder}加入到{\tt buaa}文档类的选项中可避免生僻字乱码的问题。
 \end{itemize}
 
 模板已内嵌LaTeX工具包： 


### PR DESCRIPTION
`LoadClass`应位于`ExecuteOptions`之后，这样才能把`documentclass`的选项传递给`ctexbook`。

带来的一个好处是解决了Linux环境下中文字体的问题。
CTeX在Linux下默认使用Fandol字体，某些生僻字无法显示。
利用此机制可以让`ctexbook`使用方正字体

`\documentclass[doctor,privacy,twoside,fontset=founder]{buaa}`

这样便解决了中文偏僻字（如姓名）的问题。