### PR TITLE
Times New Roman

### DIFF
--- a/Template.tex
+++ b/Template.tex
@@ -79,7 +79,7 @@
 % booktabs, longtable, multirow,
 % array, enumitem
 % algorithm2e, amsmath, amsthm, listings
-% pifont, color, soul
+% pifont, color, soul, newtxtext, newtxmath
 %--------------------
 % 请在此处添加额外工具包>>
 

--- a/buaa.cls
+++ b/buaa.cls
@@ -49,7 +49,6 @@
 \RequirePackage{geometry}     % 设置页边距
 \RequirePackage{fancyhdr}     % 设置页眉页脚
 \RequirePackage{setspace}     % 设置行间距
-\RequirePackage{times}        % Times New Roman字体
 \RequirePackage{float}        % 图片
 \RequirePackage{graphicx}     % 图片
 \RequirePackage{subfigure}    % 图片
@@ -64,6 +63,8 @@
 \RequirePackage{listings}     % 代码环境
 \RequirePackage{amsmath}      % 数学
 \RequirePackage{amsthm}       % 定理
+\RequirePackage{newtxtext}    % Times New Roman字体
+\RequirePackage{newtxmath}    % 公式的Times New Roman字体，需放置于amsthm之后
 \RequirePackage{titletoc}     % 目录
 \RequirePackage{remreset}     % 计数器设置
 \RequirePackage{hyperref}     % 超链接

--- a/tex/chap_instruction.tex
+++ b/tex/chap_instruction.tex
@@ -107,9 +107,9 @@ Again，这是北航论文\LaTeX{}模板（\CTeX{}-Based）\BUAAThesis{}。
 %-----------------------------
 \section{注意事项}
 \begin{itemize}
-  \item[$\triangleright$] 中文斜体将转换为楷体；
-  \item[$\triangleright$] 中文粗体正常；
-  \item[$\triangleright$] 英文粗体、斜体均正常；
+  \item[$\triangleright$] \textit{中文斜体}将转换为楷体；
+  \item[$\triangleright$] \textbf{中文粗体}正常；
+  \item[$\triangleright$] 英文粗体\textbf{English}、斜体\textit{English}均正常；
   \item[$\triangleright$] 中文标点的断行效果不好；
   \item[$\triangleright$] \verb|\label{<text>}|中不能使用中文；
   \item[$\triangleright$] 浮动体与正文之间的距离是弹性的；

--- a/tex/chap_instruction.tex
+++ b/tex/chap_instruction.tex
@@ -107,8 +107,9 @@ Again，这是北航论文\LaTeX{}模板（\CTeX{}-Based）\BUAAThesis{}。
 %-----------------------------
 \section{注意事项}
 \begin{itemize}
-  \item[$\triangleright$] 暂无中文斜体；
-  \item[$\triangleright$] 中文粗体将转换为楷体；
+  \item[$\triangleright$] 中文斜体将转换为楷体；
+  \item[$\triangleright$] 中文粗体正常；
+  \item[$\triangleright$] 英文粗体、斜体均正常；
   \item[$\triangleright$] 中文标点的断行效果不好；
   \item[$\triangleright$] \verb|\label{<text>}|中不能使用中文；
   \item[$\triangleright$] 浮动体与正文之间的距离是弹性的；

--- a/tex/chap_instruction.tex
+++ b/tex/chap_instruction.tex
@@ -59,7 +59,7 @@ Again，这是北航论文\LaTeX{}模板（\CTeX{}-Based）\BUAAThesis{}。
  {\tt graphicx}，{\tt subfigure}，{\tt epstopdf}，
  {\tt book\-tabs}，{\tt longtable}，{\tt multirow}，{\tt array}, {\tt enumitem}， 
  {\tt algorithm2e}，{\tt amsmath}，{\tt amsthm}，{\tt listings}，
- {\tt pifont}，{\tt color}，{\tt soul}。
+ {\tt pifont}，{\tt color}，{\tt soul}, {\tt newtxtext}, {\tt newtxmath}。
 
 模板已内嵌宏：\verb|\highlight{text}|（黄色高亮）。
 


### PR DESCRIPTION
`times`包已经被遗弃(https://ctan.org/pkg/times),
目前已经被`newtx`所替代(https://ctan.org/pkg/newtx).

CTAN上推荐转换到`newtx`，带来的一个好处就是中英文粗体、斜体都正常了。
如图：
![screenshot_20181218_163336](https://user-images.githubusercontent.com/22841309/50141585-dc18fb80-02e2-11e9-8475-493ae0d9a6e7.png)

另外，之前我Linux系统下无法英文加粗，修改后都正常了，如图：
![abc](https://user-images.githubusercontent.com/22841309/50141817-6eb99a80-02e3-11e9-8db8-519b954d9b2e.png)

还有一个改变是公式的字体，之前为默认的Computer Modern吧？现在变成Times New Roman了，如图：
![abd](https://user-images.githubusercontent.com/22841309/50142066-12a34600-02e4-11e9-9920-a241d58779de.png)
如果不需要这个特性，可以把`newtxmath`注释掉，我遇到过有的老师要求公式也是Times字体，不过好像没有硬性规定？