### PR TITLE
消除了部分警告

### DIFF
--- a/buaa.cls
+++ b/buaa.cls
@@ -163,6 +163,7 @@
 \RequirePackage{color}        % To provide color for soul
 \RequirePackage{soul}         % To highlight text
 \RequirePackage[sort&compress]{natbib}              % BibTex
+\RequirePackage{lmodern}      % 用于消除Font shape `OMX/cmex/m/n' in size <xxxx> not available 的警告
 \DeclareGraphicsExtensions{.eps,.ps,.png,.jpg,.bmp} % 声明使用图像格式
 \newcommand{\highlight}[1]{\colorbox{yellow}{#1}}   % 高亮注释
 
@@ -684,7 +685,7 @@
     \makebox[5\ccwd][s]{中图分类号}：{\bfseries \@clc}%
     \\
     \makebox[5\ccwd][s]{论文编号}：{\bfseries 10006\@studentid}%
-    \\
+
     \TranSecretLevel{\@permission}
   }
 
@@ -765,9 +766,9 @@
     {\zihao{-3} \bfseries
       \begin{tabular}{ll}
         \ifthenelse{\isundefined{\@cotutorcn}}{%
-          \makebox[70pt][s]{Candidate}:  & \@authoren \\
+          \makebox[77pt][s]{Candidate}:  & \@authoren \\
           \vspace{-10pt}\\
-          \makebox[70pt][s]{Supervisor}: & \TranDegree{\@tutordegree} \hspace{-8pt} \@tutoren \\
+          \makebox[77pt][s]{Supervisor}: & \TranDegree{\@tutordegree} \hspace{-8pt} \@tutoren \\
         }{%
           \makebox[77pt][s]{Candidate}:  & \@authoren \\
           \vspace{-10pt}\\
@@ -856,7 +857,9 @@
     航天大学或其它教育机构的学位或学历证书而使用过的材料。与我一同工作的同志对研
     究所做的任何贡献均已在论文中作出了明确的说明。
 
-      若有不实之处，本人愿意承担相关法律责任。 \\
+      若有不实之处，本人愿意承担相关法律责任。 
+
+      \hspace*{\fill}
 
       {\zihao{5}\ \ 学位论文作者签名：\underline{\hspace{7\ccwd}} \hspace{4\ccwd}
       日期：\hspace{3\ccwd}年\hspace{2\ccwd}月\hspace{2\ccwd}日}
@@ -872,7 +875,9 @@
     将学位论文的全部或部分内容编入有关数据库进行检索，采用影印、缩印或其他复制手
     段保存学位论文。
 
-        保密学位论文在解密后的使用授权同上。 \\
+        保密学位论文在解密后的使用授权同上。 
+
+        \hspace*{\fill}
 
         {\zihao{5}\ \ 学位论文作者签名：\underline{\hspace{7\ccwd}} \hspace{4\ccwd}
         日期：\hspace{3\ccwd}年\hspace{2\ccwd}月\hspace{2\ccwd}日}


### PR DESCRIPTION
修改了buaa.cls中会导致出现警告的几处设定，并在视觉效果上和原本的pdf保持了一致（但是没有具体对照相应规定文档）
我的环境：win10, TeX 3.141592653 (TeX Live 2022)，XeTeX 3.141592653-2.6-0.999994 (TeX Live 2022)
1. 添加了\RequirePackage{lmodern} 以消除Font shape `OMX/cmex/m/n' in size <xxxx> not available 的警告
2. 688行处使用\\结尾会导致“Underfull \hbox”的警告，去除\\后可以消除
3. 769行和771行处原本将box大小设定为70pt会导致在导师名字稍微长的时候产生“Overfull \hbox”的警告，我将其和下边的77pt大小的box统一后可以消除这一警告
4. 860行和878行处原本均为在最后一段结尾处使用\\，均会导致“Underfull \hbox”警告，因此将其替换为两次换行+使用空格占行的形式，可以避免这一警告

强迫症发作调整了一晚上的结果，虽然仍有几处Underfull没消掉，但希望目前这几个有用